### PR TITLE
updated rds sg rules to allow odp db server

### DIFF
--- a/global.tf
+++ b/global.tf
@@ -19,6 +19,7 @@ variable "names" {
       "maintenancewindow"     = "Sat:04:00-Sat:05:00"
       "storageencrypted"      = true
       "grant_dev_db_access"   = true
+      "grant_odp_db_access"   = false
       "ecs_subnet"            = ["subnet-067afb7d7e5af4f36", "subnet-0ab17287bb419808a"]
       "lb_subnet"             = ["subnet-04ad191ac2b66d763", "subnet-093eeb64493db3d5f"]
       "rds_instance_count"    = "1"
@@ -49,6 +50,7 @@ variable "names" {
       "maintenancewindow"     = "Sat:04:00-Sat:05:00"
       "storageencrypted"      = true
       "grant_dev_db_access"   = true
+      "grant_odp_db_access"   = false
       "ecs_subnet"            = ["subnet-013380fc814fcd7a8", "subnet-026e43c345c497f81"]
       "lb_subnet"             = ["subnet-012b28f51a536264f", "subnet-0b31379ceb59b3aa2"]
       "rds_instance_count"    = "1"
@@ -79,6 +81,7 @@ variable "names" {
       "maintenancewindow"     = "Sat:04:00-Sat:05:00"
       "storageencrypted"      = true
       "grant_dev_db_access"   = true
+      "grant_odp_db_access"   = true
       "ecs_subnet"            = ["subnet-014f7c22b8ca588d2", "subnet-0393f098f6159948e"]
       "lb_subnet"             = ["subnet-0eda6aac2aa3f6a8a", "subnet-0e0d905781bfc0687"]
       "container_image_url"   = ""
@@ -110,6 +113,7 @@ variable "names" {
       "maintenancewindow"     = "Sat:04:00-Sat:05:00"
       "storageencrypted"      = true
       "grant_dev_db_access"   = true
+      "grant_odp_db_access"   = true
       "ecs_subnet"            = ["subnet-0c5ed34136a1896d5", "subnet-0c599b4c6ea142959", "subnet-052279d19b778a506"]
       "lb_subnet"             = ["subnet-046f1aadc23c50b9c", "subnet-07cb31be0a01cd0ca", "subnet-0f176c1fd30d60574"]
       "rds_instance_count"    = "3"
@@ -140,6 +144,7 @@ variable "names" {
       "maintenancewindow"     = "Sat:04:00-Sat:05:00"
       "storageencrypted"      = true
       "grant_dev_db_access"   = true
+      "grant_odp_db_access"   = true
       "ecs_subnet"            = ["subnet-05f4307eb2a2d1f10", "subnet-080e771c9db3aa1fc", "subnet-025c35dccad5330e4"]
       "lb_subnet"             = ["subnet-0f22b341632d789a6", "subnet-0122964cc845a1b61", "subnet-035cab03e4bd37e4f"]
       "rds_instance_count"    = "3"

--- a/main.tf
+++ b/main.tf
@@ -57,6 +57,7 @@ module "rds_aurora" {
   backup_retention_period = var.names["${var.env}"]["backupretentionperiod"]
   maintenance_window      = var.names["${var.env}"]["maintenancewindow"]
   grant_dev_db_access     = var.names["${var.env}"]["grant_dev_db_access"]
+  grant_odp_db_access     = var.names["${var.env}"]["grant_odp_db_access"]
   subnet_group            = "${var.names["${var.env}"]["accountidentifiers"]}-rds-sng-${var.env}-public"
   db_name                 = "sponsorengagement"
   username                = jsondecode(data.aws_secretsmanager_secret_version.terraform_secret_version.secret_string)["db-username"]
@@ -70,7 +71,7 @@ module "rds_aurora" {
   add_scheduler_tag       = var.names["${var.env}"]["add_scheduler_tag"]
   ecs_sg                  = module.ecs.ecs_sg
   whitelist_ips           = jsondecode(data.aws_secretsmanager_secret_version.terraform_secret_version.secret_string)["whitelist-ips"]
-
+  odp_db_server_ip        = jsondecode(data.aws_secretsmanager_secret_version.terraform_secret_version.secret_string)["odp-db-server-ip"]
 }
 
 ## ECS FARGATE

--- a/modules/auroradb/db.tf
+++ b/modules/auroradb/db.tf
@@ -6,11 +6,6 @@ resource "aws_security_group" "sg-rds" {
   name        = "${var.account}-sg-rds-aurora-${var.env}-${var.app}"
   description = "Allow MYSQL inbound traffic"
   vpc_id      = var.vpc_id
-  lifecycle {
-    ignore_changes = [ 
-      ingress
-     ]
-  }
 
   ingress {
     description     = "ecs-to-rds"
@@ -28,6 +23,17 @@ resource "aws_security_group" "sg-rds" {
       to_port     = 3306
       protocol    = "tcp"
       cidr_blocks = var.whitelist_ips
+    }
+  }
+
+    dynamic "ingress" {
+    for_each = var.grant_odp_db_access ? [1] : []
+    content {
+      description = "ODP DB IP"
+      from_port   = 3306
+      to_port     = 3306
+      protocol    = "tcp"
+      cidr_blocks = var.odp_db_server_ip
     }
   }
 

--- a/modules/auroradb/var.tf
+++ b/modules/auroradb/var.tf
@@ -48,7 +48,10 @@ variable "maintenance_window" {
 
 variable "grant_dev_db_access" {
   default = true
+}
 
+variable "grant_odp_db_access" {
+  default = true
 }
 
 variable "az_zones" {
@@ -107,4 +110,7 @@ variable "ecs_sg" {
 # }
 
 variable "whitelist_ips" {
+}
+
+variable "odp_db_server_ip" {
 }


### PR DESCRIPTION
Previous PR did not allow us to manage both security group ips in the code and aws console, so this PR will revert that and pull the odp db server IPs from secrets for the relevant environment.