### PR TITLE
updated scheduler tag to rds-se

### DIFF
--- a/modules/auroradb/db.tf
+++ b/modules/auroradb/db.tf
@@ -122,7 +122,7 @@ resource "aws_rds_cluster" "rds_cluster" {
       System           = var.app
       aws-backup-daily = true
     },
-    var.add_scheduler_tag ? { "instance-scheduler" = "rds-frf" } : {},
+    var.add_scheduler_tag ? { "instance-scheduler" = "rds-se" } : {},
     var.env == "prod" ? { "aws-backup-daily" = "true" } : {},
     var.env == "prod" ? { "aws-backup-weekly" = "true" } : {},
   )


### PR DESCRIPTION
Update to the tag value that schedules non-prod RDS instances. This was set to the same one as for frf, but they might need different schedules in the futures, so this allows for this.