### PR TITLE
add uat rds scheduler tag

### DIFF
--- a/global.tf
+++ b/global.tf
@@ -99,7 +99,7 @@ variable "names" {
       "max_capacity"          = 4
       "log_types"             = ["error", "general", "slowquery", "audit"]
       "publicly_accessible"   = true
-      "add_scheduler_tag"     = false
+      "add_scheduler_tag"     = true
       "ecs_instance_count"    = 1
       "waf_create"            = "true"
       "whitelist_ips"         = ["0.0.0.0/0"]


### PR DESCRIPTION
Add back the uat RDS scheduler tag that was removed to keep the db on over the weekend for a process run